### PR TITLE
fix api key entry functionality

### DIFF
--- a/build-main.sh
+++ b/build-main.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Build script for MenubarGPT main target only
+# This avoids issues with empty test targets
+
+echo "Building MenubarGPT (main target only)..."
+xcodebuild -project MenubarGPT.xcodeproj -target MenubarGPT build
+
+if [ $? -eq 0 ]; then
+    echo "Build successful!"
+else
+    echo "Build failed!"
+    exit 1
+fi


### PR DESCRIPTION
add focusstate for textfield flow  
auto focus api key input  
debug prints for troubleshooting  
add save-only button (skip api validation)  
use saveapikey to bypass format check  
refresh hasapikey on settings save  
better ux with button states + validation feedback  
